### PR TITLE
fix(fish): restore old ctrl-c behaviour

### DIFF
--- a/nix/fish/.config/fish/conf.d/common/config.fish
+++ b/nix/fish/.config/fish/conf.d/common/config.fish
@@ -2,3 +2,7 @@ set -g fish_color_command brwhite
 set -g fish_prompt_pwd_dir_length 0
 
 set -g color_path_basename white
+
+# For fish >= 4 bring back the old ctrl-c behaviour:
+#   leave the current cancelled command, print the cancel mark and print the new prompt.
+bind ctrl-c cancel-commandline


### PR DESCRIPTION
According to [release notes of version 4.0.0](https://fishshell.com/docs/current/relnotes.html#notable-backwards-incompatible-changes):
> ctrl-c now calls a new bind function called clear-commandline. The old behavior, which leaves a “^C” marker, is available as cancel-commandline

So, restore the old behaviour.